### PR TITLE
feat: add gitrepo controller

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -24,7 +24,10 @@ resources:
   webhooks:
     defaulting: true
     webhookVersion: v1
-- controller: true
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
   domain: thegeeklab.de
   group: renovate
   kind: Discovery
@@ -36,6 +39,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+  controller: true
   domain: thegeeklab.de
   group: renovate
   kind: GitRepo

--- a/api/v1beta1/gitrepo_types.go
+++ b/api/v1beta1/gitrepo_types.go
@@ -7,6 +7,10 @@ import (
 // GitRepoSpec defines the desired state of GitRepo.
 type GitRepoSpec struct {
 	Name string `json:"name"`
+
+	//+kubebuilder:validation:Optional
+	ConfigRef string `json:"configRef,omitempty"`
+
 	// +kubebuilder:validation:Optional
 	WebhookID string `json:"webhookId,omitempty"`
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/open-policy-agent/cert-controller/pkg/rotator"
 	renovatev1beta1 "github.com/thegeeklab/renovate-operator/api/v1beta1"
 	"github.com/thegeeklab/renovate-operator/internal/controller/discovery"
+	"github.com/thegeeklab/renovate-operator/internal/controller/gitrepo"
 	"github.com/thegeeklab/renovate-operator/internal/controller/renovator"
 	runner "github.com/thegeeklab/renovate-operator/internal/controller/runner"
 	"github.com/thegeeklab/renovate-operator/internal/frontend"
@@ -226,6 +227,15 @@ func main() {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", renovator.ControllerName)
+		os.Exit(1)
+	}
+
+	// gitrepo
+	if err = (&gitrepo.Reconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "Unable to create controller", "controller", gitrepo.ControllerName)
 		os.Exit(1)
 	}
 

--- a/config/crd/bases/renovate.thegeeklab.de_gitrepos.yaml
+++ b/config/crd/bases/renovate.thegeeklab.de_gitrepos.yaml
@@ -39,6 +39,8 @@ spec:
             spec:
               description: GitRepoSpec defines the desired state of GitRepo.
               properties:
+                configRef:
+                  type: string
                 name:
                   type: string
                 webhookId:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -198,6 +198,8 @@ spec:
             spec:
               description: GitRepoSpec defines the desired state of GitRepo.
               properties:
+                configRef:
+                  type: string
                 name:
                   type: string
                 webhookId:

--- a/internal/component/gitrepo/job.go
+++ b/internal/component/gitrepo/job.go
@@ -18,6 +18,10 @@ import (
 func (r *Reconciler) reconcileBatchJob(ctx context.Context) (*ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
+	if !renovator.HasRenovatorOperationRenovate(r.instance.Annotations) {
+		return &ctrl.Result{}, nil
+	}
+
 	// Check for active renovate jobs with our specific labels
 	active, err := cronjob.CheckActiveJobs(ctx, r.Client, r.instance.Namespace, runner.RunnerName(r.req))
 	if err != nil {

--- a/internal/component/gitrepo/job.go
+++ b/internal/component/gitrepo/job.go
@@ -1,0 +1,69 @@
+package gitrepo
+
+import (
+	"context"
+
+	"github.com/thegeeklab/renovate-operator/internal/component/renovator"
+	"github.com/thegeeklab/renovate-operator/internal/component/runner"
+	"github.com/thegeeklab/renovate-operator/internal/metadata"
+	cronjob "github.com/thegeeklab/renovate-operator/internal/resource/cronjob"
+	"github.com/thegeeklab/renovate-operator/internal/resource/renovate"
+	"github.com/thegeeklab/renovate-operator/pkg/util/k8s"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func (r *Reconciler) reconcileBatchJob(ctx context.Context) (*ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	// Check for active renovate jobs with our specific labels
+	active, err := cronjob.CheckActiveJobs(ctx, r.Client, r.instance.Namespace, runner.RunnerName(r.req))
+	if err != nil {
+		return &ctrl.Result{}, err
+	}
+
+	if active {
+		log.V(1).Info("Active renovate jobs found, requeuing", "delay", cronjob.RequeueDelay)
+
+		return &ctrl.Result{RequeueAfter: cronjob.RequeueDelay}, nil
+	}
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: runner.RunnerName(r.req) + "-",
+			Namespace:    r.instance.Namespace,
+		},
+		Spec: batchv1.JobSpec{},
+	}
+
+	r.updateJobSpec(&job.Spec)
+
+	if _, err := k8s.CreateOrUpdate(ctx, r.Client, job, r.instance, nil); err != nil {
+		return &ctrl.Result{}, err
+	}
+
+	// Remove renovate annotation
+	r.instance.Annotations = renovator.RemoveRenovatorOperation(r.instance.Annotations)
+	if err := r.Update(ctx, r.instance); err != nil {
+		return &ctrl.Result{}, err
+	}
+
+	return &ctrl.Result{}, nil
+}
+
+func (r *Reconciler) updateJobSpec(spec *batchv1.JobSpec) {
+	renovateConfigCM := metadata.GenericName(r.req, renovator.ConfigMapSuffix)
+
+	if spec == nil {
+		spec = &batchv1.JobSpec{}
+	}
+
+	renovate.DefaultJobSpec(
+		spec,
+		r.renovate,
+		renovateConfigCM,
+		renovate.WithSingleRepoMode(r.instance.Name),
+	)
+}

--- a/internal/component/gitrepo/reconciler.go
+++ b/internal/component/gitrepo/reconciler.go
@@ -1,0 +1,57 @@
+package gitrepo
+
+import (
+	"context"
+	"fmt"
+
+	renovatev1beta1 "github.com/thegeeklab/renovate-operator/api/v1beta1"
+	"github.com/thegeeklab/renovate-operator/pkg/util/reconciler"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Reconciler struct {
+	client.Client
+	scheme   *runtime.Scheme
+	req      ctrl.Request
+	instance *renovatev1beta1.GitRepo
+	renovate *renovatev1beta1.RenovateConfig
+}
+
+func NewReconciler(
+	_ context.Context,
+	c client.Client,
+	scheme *runtime.Scheme,
+	instance *renovatev1beta1.GitRepo,
+	renovate *renovatev1beta1.RenovateConfig,
+) (*Reconciler, error) {
+	return &Reconciler{
+		Client:   c,
+		scheme:   scheme,
+		req:      ctrl.Request{NamespacedName: client.ObjectKey{Namespace: instance.Namespace, Name: instance.Name}},
+		instance: instance,
+		renovate: renovate,
+	}, nil
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context) (*ctrl.Result, error) {
+	results := &reconciler.Results{}
+
+	// Define the reconciliation order
+	reconcileFuncs := []func(context.Context) (*ctrl.Result, error){
+		r.reconcileBatchJob,
+	}
+
+	// Execute each reconciliation step
+	for _, reconcileFunc := range reconcileFuncs {
+		res, err := reconcileFunc(ctx)
+		if err != nil {
+			return &ctrl.Result{}, fmt.Errorf("reconciliation failed: %w", err)
+		}
+
+		results.Collect(res)
+	}
+
+	return results.ToResult(), nil
+}

--- a/internal/component/gitrepo/suite_test.go
+++ b/internal/component/gitrepo/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestDiscovery(t *testing.T) {
+func TestGitRepo(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "GitRepo Suite")
 }

--- a/internal/component/gitrepo/suite_test.go
+++ b/internal/component/gitrepo/suite_test.go
@@ -1,0 +1,13 @@
+package gitrepo
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDiscovery(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "GitRepo Suite")
+}

--- a/internal/controller/gitrepo/controller.go
+++ b/internal/controller/gitrepo/controller.go
@@ -1,0 +1,162 @@
+package gitrepo
+
+import (
+	"context"
+
+	renovatev1beta1 "github.com/thegeeklab/renovate-operator/api/v1beta1"
+	"github.com/thegeeklab/renovate-operator/internal/component/gitrepo"
+	"github.com/thegeeklab/renovate-operator/internal/component/renovator"
+	"github.com/thegeeklab/renovate-operator/internal/controller"
+	batchv1 "k8s.io/api/batch/v1"
+	api_errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const ControllerName = "gitrepo"
+
+// Reconciler reconciles a Renovator object.
+type Reconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+//nolint:lll
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+
+// +kubebuilder:rbac:groups=renovate.thegeeklab.de,resources=discoveries,verbs=get;list;watch
+// +kubebuilder:rbac:groups=renovate.thegeeklab.de,resources=discoveries/status,verbs=get
+// +kubebuilder:rbac:groups=renovate.thegeeklab.de,resources=gitrepos,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=renovate.thegeeklab.de,resources=gitrepos/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=renovate.thegeeklab.de,resources=gitrepos/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.0/pkg/reconcile
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+	log.V(1).Info("Reconciling object", "object", req.NamespacedName)
+
+	rd := &renovatev1beta1.GitRepo{}
+	if err := r.Get(ctx, req.NamespacedName, rd); err != nil {
+		if api_errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, err
+	}
+
+	rcNamespacedName, err := r.resolveRenovateConfig(ctx, req.Namespace, rd)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	rc := &renovatev1beta1.RenovateConfig{}
+	if err := r.Get(ctx, rcNamespacedName, rc); err != nil {
+		if api_errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, err
+	}
+
+	gitrepo, err := gitrepo.NewReconciler(ctx, r.Client, r.Scheme, rd, rc)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	res, err := gitrepo.Reconcile(ctx)
+	if err != nil {
+		return controller.HandleReconcileResult(res, err)
+	}
+
+	return *res, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	const configRefIndexKey = ".spec.configRef"
+
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&renovatev1beta1.GitRepo{},
+		configRefIndexKey,
+		gitrepoConfigRefIndexFn,
+	); err != nil {
+		return err
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&renovatev1beta1.GitRepo{}).
+		WithEventFilter(predicate.Or(
+			predicate.GenerationChangedPredicate{},
+			predicate.Funcs{
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					oldAnn := e.ObjectOld.GetAnnotations()
+					newAnn := e.ObjectNew.GetAnnotations()
+
+					return renovator.HasRenovatorOperationRenovate(newAnn) &&
+						!renovator.HasRenovatorOperationRenovate(oldAnn)
+				},
+				CreateFunc:  func(_ event.CreateEvent) bool { return true },
+				DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+				GenericFunc: func(_ event.GenericEvent) bool { return false },
+			},
+		)).
+		Owns(&batchv1.Job{}).
+		Named(ControllerName).
+		Complete(r)
+}
+
+// resolveRenovateConfig resolves the RenovateConfig name from either .spec.configRef or renovatev1beta1.RenovatorLabel.
+func (r *Reconciler) resolveRenovateConfig(
+	ctx context.Context,
+	namespace string,
+	rd *renovatev1beta1.GitRepo,
+) (client.ObjectKey, error) {
+	if rd.Spec.ConfigRef != "" {
+		return client.ObjectKey{Namespace: namespace, Name: rd.Spec.ConfigRef}, nil
+	}
+
+	renovator, ok := rd.Labels[renovatev1beta1.RenovatorLabel]
+	if !ok {
+		return client.ObjectKey{}, controller.ErrNoRenovateConfigFound
+	}
+
+	configList := &renovatev1beta1.RenovateConfigList{}
+	if err := r.List(ctx, configList, client.InNamespace(namespace)); err != nil {
+		return client.ObjectKey{}, err
+	}
+
+	for _, config := range configList.Items {
+		if config.Labels != nil && config.Labels[renovatev1beta1.RenovatorLabel] == renovator {
+			return client.ObjectKey{Namespace: namespace, Name: config.Name}, nil
+		}
+	}
+
+	return client.ObjectKey{}, controller.ErrNoRenovateConfigFound
+}
+
+// gitrepoConfigRefIndexFn returns the config reference for indexing.
+func gitrepoConfigRefIndexFn(rawObj client.Object) []string {
+	gitrepo, ok := rawObj.(*renovatev1beta1.GitRepo)
+	if !ok {
+		return nil
+	}
+
+	if gitrepo.Spec.ConfigRef == "" {
+		return nil
+	}
+
+	return []string{gitrepo.Spec.ConfigRef}
+}

--- a/internal/controller/gitrepo/controller.go
+++ b/internal/controller/gitrepo/controller.go
@@ -25,16 +25,8 @@ type Reconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//nolint:lll
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 
-// +kubebuilder:rbac:groups=renovate.thegeeklab.de,resources=discoveries,verbs=get;list;watch
-// +kubebuilder:rbac:groups=renovate.thegeeklab.de,resources=discoveries/status,verbs=get
 // +kubebuilder:rbac:groups=renovate.thegeeklab.de,resources=gitrepos,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=renovate.thegeeklab.de,resources=gitrepos/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=renovate.thegeeklab.de,resources=gitrepos/finalizers,verbs=update

--- a/internal/controller/gitrepo/controller_test.go
+++ b/internal/controller/gitrepo/controller_test.go
@@ -1,0 +1,167 @@
+package gitrepo
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	renovatev1beta1 "github.com/thegeeklab/renovate-operator/api/v1beta1"
+	v1beta1 "github.com/thegeeklab/renovate-operator/internal/webhook/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	api_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("GitRepo Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-gitrepo"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind GitRepo")
+
+			// Create RenovateConfig resource first
+			config := &renovatev1beta1.RenovateConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-config",
+					Namespace: "default",
+				},
+				Spec: renovatev1beta1.RenovateConfigSpec{
+					Platform: renovatev1beta1.PlatformSpec{
+						Type: "github",
+						Token: corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "renovate-token-secret",
+								},
+								Key: "token",
+							},
+						},
+						Endpoint: "https://api.github.com/",
+					},
+				},
+			}
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: "test-config", Namespace: "default"}, config)
+			if err != nil && api_errors.IsNotFound(err) {
+				// Apply webhook defaulter
+				rcd := &v1beta1.RenovateConfigCustomDefaulter{}
+				Expect(rcd.Default(ctx, config)).To(Succeed())
+				Expect(k8sClient.Create(ctx, config)).To(Succeed())
+			}
+
+			// Create GitRepo resource
+			err = k8sClient.Get(ctx, typeNamespacedName, &renovatev1beta1.GitRepo{})
+			if err != nil && api_errors.IsNotFound(err) {
+				resource := &renovatev1beta1.GitRepo{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					Spec: renovatev1beta1.GitRepoSpec{
+						Name:      "test-repo",
+						ConfigRef: "test-config",
+					},
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// Cleanup RenovateConfig resource
+			config := &renovatev1beta1.RenovateConfig{}
+			configErr := k8sClient.Get(ctx, types.NamespacedName{Name: "test-config", Namespace: "default"}, config)
+			if configErr == nil {
+				Expect(k8sClient.Delete(ctx, config)).To(Succeed())
+			}
+
+			// Cleanup GitRepo resource
+			resource := &renovatev1beta1.GitRepo{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance GitRepo")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &Reconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+		})
+
+		It("should handle missing GitRepo resource", func() {
+			By("Testing reconciliation with non-existent GitRepo")
+			controllerReconciler := &Reconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			nonExistentName := types.NamespacedName{
+				Name:      "non-existent-gitrepo",
+				Namespace: "default",
+			}
+
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: nonExistentName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+		})
+
+		It("should handle errors from gitrepo component", func() {
+			By("Testing error handling in gitrepo component")
+			// Create a mock client that returns an error when creating gitrepo component
+			mockClient := &mockErrorClient{
+				Client: k8sClient,
+			}
+
+			errorReconciler := &Reconciler{
+				Client: mockClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			// The mock client returns NotFound for RenovateConfig, which should be handled gracefully
+			result, err := errorReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+		})
+	})
+})
+
+// mockErrorClient is a mock client that returns errors for testing.
+type mockErrorClient struct {
+	client.Client
+}
+
+func (m *mockErrorClient) Get(
+	ctx context.Context,
+	key client.ObjectKey,
+	obj client.Object,
+	opts ...client.GetOption,
+) error {
+	// Return error for RenovateConfig to simulate missing config
+	if _, ok := obj.(*renovatev1beta1.RenovateConfig); ok {
+		return api_errors.NewNotFound(renovatev1beta1.GroupVersion.WithResource("renovateconfigs").GroupResource(), key.Name)
+	}
+
+	return m.Client.Get(ctx, key, obj, opts...)
+}

--- a/internal/controller/gitrepo/suite_test.go
+++ b/internal/controller/gitrepo/suite_test.go
@@ -1,0 +1,103 @@
+package gitrepo
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	renovatev1beta1 "github.com/thegeeklab/renovate-operator/api/v1beta1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	k8sClient client.Client
+)
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "GitRepoController Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.Background())
+
+	var err error
+	err = renovatev1beta1.AddToScheme(clientgoscheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	// Retrieve the first found binary directory to allow running tests from IDEs
+	if getFirstFoundEnvTestBinaryDir() != "" {
+		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
+	}
+
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: clientgoscheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
+// ENVTEST-based tests depend on specific binaries, usually located in paths set by
+// controller-runtime. When running tests directly (e.g., via an IDE) without using
+// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
+//
+// This function streamlines the process by finding the required binaries, similar to
+// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
+// properly set up, run 'make setup-envtest' beforehand.
+func getFirstFoundEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
+
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+
+		return ""
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+
+	return ""
+}

--- a/internal/resource/container/suite_test.go
+++ b/internal/resource/container/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestContainers(t *testing.T) {
+func TestContainer(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Containers Suite")
+	RunSpecs(t, "Container Suite")
 }

--- a/internal/resource/cronjob/suite_test.go
+++ b/internal/resource/cronjob/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestDiscovery(t *testing.T) {
+func TestCronJob(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CronJob Suite")
 }

--- a/pkg/dispatcher/suite_test.go
+++ b/pkg/dispatcher/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestDiscovery(t *testing.T) {
+func TestDispatcher(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Dispatcher Suite")
 }

--- a/pkg/util/suite_test.go
+++ b/pkg/util/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestDiscovery(t *testing.T) {
+func TestUtil(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Util Suite")
 }


### PR DESCRIPTION
We already support annotating runner resources with `renovate.thegeeklab.de/operation=renovate`. With the introduction of the gitrepo controller its now also possible to use this annotation on gitrepo resources to trigger an immediate renovate rune for a single repo.