### PR TITLE
feat: support authprovider display name and icon url

### DIFF
--- a/api/v1beta1/authprovider_types.go
+++ b/api/v1beta1/authprovider_types.go
@@ -14,9 +14,6 @@ type AuthProviderSpec struct {
 	// Endpoint is the base URL of the Git platform.
 	Endpoint string `json:"endpoint"`
 
-	// IssuerURL is the OIDC issuer URL for authentication.
-	IssuerURL string `json:"issuerUrl"`
-
 	// ClientID is the OAuth2 client ID.
 	ClientID string `json:"clientId"`
 
@@ -26,17 +23,27 @@ type AuthProviderSpec struct {
 	// RedirectURL is the OAuth2 callback URL.
 	RedirectURL string `json:"redirectUrl"`
 
-	// ForgeURL is the API URL for the Git platform. If empty, the controller will use Endpoint.
+	// ForgeURL is the API URL for the Git platform. Defaults to Endpoint.
 	// +kubebuilder:validation:Optional
 	ForgeURL string `json:"forgeUrl,omitempty"`
 
-	// AuthURL is a custom OAuth2 authorization URL.
+	// AuthURL is a custom OAuth2 authorization URL. Derived from Type and Endpoint if not specified.
 	// +kubebuilder:validation:Optional
 	AuthURL string `json:"authUrl,omitempty"`
 
 	// Insecure disables TLS verification (not recommended for production).
 	// +kubebuilder:validation:Optional
 	Insecure bool `json:"insecure,omitempty"`
+
+	// DisplayName is a human-readable name shown in the login UI.
+	// Derived from the Endpoint hostname when empty.
+	// +kubebuilder:validation:Optional
+	DisplayName string `json:"displayName,omitempty"`
+
+	// IconURL is the URL of an icon shown next to the provider in the login UI.
+	// Defaults to the Endpoint's favicon.ico when empty.
+	// +kubebuilder:validation:Optional
+	IconURL string `json:"iconUrl,omitempty"`
 }
 
 // AuthProviderStatus defines the observed state of AuthProvider.

--- a/config/crd/bases/renovate.thegeeklab.de_authproviders.yaml
+++ b/config/crd/bases/renovate.thegeeklab.de_authproviders.yaml
@@ -40,7 +40,7 @@ spec:
               description: AuthProviderSpec defines the desired state of AuthProvider.
               properties:
                 authUrl:
-                  description: AuthURL is a custom OAuth2 authorization URL.
+                  description: AuthURL is a custom OAuth2 authorization URL. Derived from Type and Endpoint if not specified.
                   type: string
                 clientId:
                   description: ClientID is the OAuth2 client ID.
@@ -67,18 +67,25 @@ spec:
                     - key
                   type: object
                   x-kubernetes-map-type: atomic
+                displayName:
+                  description: |-
+                    DisplayName is a human-readable name shown in the login UI.
+                    Derived from the Endpoint hostname when empty.
+                  type: string
                 endpoint:
                   description: Endpoint is the base URL of the Git platform.
                   type: string
                 forgeUrl:
-                  description: ForgeURL is the API URL for the Git platform. If empty, the controller will use Endpoint.
+                  description: ForgeURL is the API URL for the Git platform. Defaults to Endpoint.
+                  type: string
+                iconUrl:
+                  description: |-
+                    IconURL is the URL of an icon shown next to the provider in the login UI.
+                    Defaults to the Endpoint's favicon.ico when empty.
                   type: string
                 insecure:
                   description: Insecure disables TLS verification (not recommended for production).
                   type: boolean
-                issuerUrl:
-                  description: IssuerURL is the OIDC issuer URL for authentication.
-                  type: string
                 redirectUrl:
                   description: RedirectURL is the OAuth2 callback URL.
                   type: string
@@ -92,7 +99,6 @@ spec:
                 - clientId
                 - clientSecret
                 - endpoint
-                - issuerUrl
                 - redirectUrl
                 - type
               type: object

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -49,7 +49,7 @@ spec:
               description: AuthProviderSpec defines the desired state of AuthProvider.
               properties:
                 authUrl:
-                  description: AuthURL is a custom OAuth2 authorization URL.
+                  description: AuthURL is a custom OAuth2 authorization URL. Derived from Type and Endpoint if not specified.
                   type: string
                 clientId:
                   description: ClientID is the OAuth2 client ID.
@@ -76,18 +76,25 @@ spec:
                     - key
                   type: object
                   x-kubernetes-map-type: atomic
+                displayName:
+                  description: |-
+                    DisplayName is a human-readable name shown in the login UI.
+                    Derived from the Endpoint hostname when empty.
+                  type: string
                 endpoint:
                   description: Endpoint is the base URL of the Git platform.
                   type: string
                 forgeUrl:
-                  description: ForgeURL is the API URL for the Git platform. If empty, the controller will use Endpoint.
+                  description: ForgeURL is the API URL for the Git platform. Defaults to Endpoint.
+                  type: string
+                iconUrl:
+                  description: |-
+                    IconURL is the URL of an icon shown next to the provider in the login UI.
+                    Defaults to the Endpoint's favicon.ico when empty.
                   type: string
                 insecure:
                   description: Insecure disables TLS verification (not recommended for production).
                   type: boolean
-                issuerUrl:
-                  description: IssuerURL is the OIDC issuer URL for authentication.
-                  type: string
                 redirectUrl:
                   description: RedirectURL is the OAuth2 callback URL.
                   type: string
@@ -101,7 +108,6 @@ spec:
                 - clientId
                 - clientSecret
                 - endpoint
-                - issuerUrl
                 - redirectUrl
                 - type
               type: object

--- a/internal/controller/authprovider/controller.go
+++ b/internal/controller/authprovider/controller.go
@@ -207,13 +207,15 @@ func (r *Reconciler) createAuthProvider(
 
 	cfg := auth.ProviderConfig{
 		Name:         ap.Name,
+		DisplayName:  ap.Spec.DisplayName,
 		Type:         string(ap.Spec.Type),
-		IssuerURL:    ap.Spec.IssuerURL,
+		Endpoint:     ap.Spec.Endpoint,
 		ClientID:     ap.Spec.ClientID,
 		ClientSecret: clientSecret,
 		RedirectURL:  ap.Spec.RedirectURL,
 		ForgeURL:     forgeURL,
 		AuthURL:      ap.Spec.AuthURL,
+		IconURL:      ap.Spec.IconURL,
 		Insecure:     ap.Spec.Insecure,
 	}
 

--- a/internal/controller/authprovider/controller_test.go
+++ b/internal/controller/authprovider/controller_test.go
@@ -65,9 +65,8 @@ var _ = Describe("AuthProvider Controller", func() {
 					Namespace: "default",
 				},
 				Spec: renovatev1beta1.AuthProviderSpec{
-					Type:      "gitea",
-					Endpoint:  "https://gitea.example.com",
-					IssuerURL: "https://gitea.example.com",
+					Type:     "gitea",
+					Endpoint: "https://gitea.example.com",
 					ClientSecret: corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",
@@ -244,6 +243,14 @@ func (m *mockAuthProvider) Type() string {
 
 func (m *mockAuthProvider) Name() string {
 	return m.name
+}
+
+func (m *mockAuthProvider) DisplayName() string {
+	return m.name
+}
+
+func (m *mockAuthProvider) IconURL() string {
+	return ""
 }
 
 func (m *mockAuthProvider) LoginURL(_ string) string {

--- a/internal/frontend/auth/gitea/provider.go
+++ b/internal/frontend/auth/gitea/provider.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -53,7 +54,9 @@ type giteaRepo struct {
 
 type GiteaProvider struct {
 	name         string
-	issuerURL    string
+	displayName  string
+	iconURL      string
+	endpoint     string
 	clientID     string
 	clientSecret string
 	redirectURL  string
@@ -74,7 +77,7 @@ func NewGiteaProvider(ctx context.Context, cfg auth.ProviderConfig) (*GiteaProvi
 
 	ctx = oidc.ClientContext(ctx, httpClient)
 
-	provider, err := oidc.NewProvider(ctx, cfg.IssuerURL)
+	provider, err := oidc.NewProvider(ctx, cfg.Endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover OIDC provider: %w", err)
 	}
@@ -82,13 +85,23 @@ func NewGiteaProvider(ctx context.Context, cfg auth.ProviderConfig) (*GiteaProvi
 	oidcConfig := &oidc.Config{ClientID: cfg.ClientID}
 
 	endpoint := provider.Endpoint()
-	if cfg.AuthURL != "" {
-		endpoint.AuthURL = cfg.AuthURL
+	endpoint.AuthURL = resolveAuthURL(cfg.AuthURL, cfg.Endpoint)
+
+	displayName := cfg.DisplayName
+	if displayName == "" {
+		displayName = hostFromURL(resolveAuthURL(cfg.AuthURL, cfg.Endpoint))
+	}
+
+	iconURL := cfg.IconURL
+	if iconURL == "" {
+		iconURL = faviconURL(resolveAuthURL(cfg.AuthURL, cfg.Endpoint))
 	}
 
 	return &GiteaProvider{
 		name:         cfg.Name,
-		issuerURL:    cfg.IssuerURL,
+		displayName:  displayName,
+		iconURL:      iconURL,
+		endpoint:     cfg.Endpoint,
 		clientID:     cfg.ClientID,
 		clientSecret: cfg.ClientSecret,
 		redirectURL:  cfg.RedirectURL,
@@ -112,6 +125,14 @@ func (p *GiteaProvider) Type() string {
 
 func (p *GiteaProvider) Name() string {
 	return p.name
+}
+
+func (p *GiteaProvider) DisplayName() string {
+	return p.displayName
+}
+
+func (p *GiteaProvider) IconURL() string {
+	return p.iconURL
 }
 
 func (p *GiteaProvider) LoginURL(state string) string {
@@ -332,4 +353,30 @@ func (p *GiteaProvider) parseRetryAfter(resp *http.Response) time.Duration {
 	}
 
 	return 0
+}
+
+func hostFromURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	return u.Host
+}
+
+func faviconURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+
+	return fmt.Sprintf("%s://%s/favicon.ico", u.Scheme, u.Host)
+}
+
+func resolveAuthURL(override, issuerURL string) string {
+	if override != "" {
+		return override
+	}
+
+	return strings.TrimRight(issuerURL, "/") + "/login/oauth/authorize"
 }

--- a/internal/frontend/auth/gitea/provider_test.go
+++ b/internal/frontend/auth/gitea/provider_test.go
@@ -396,7 +396,7 @@ var _ = Describe("GiteaProvider", func() {
 
 			provider := &GiteaProvider{
 				name:         "test",
-				issuerURL:    testSrv.URL,
+				endpoint:     testSrv.URL,
 				clientID:     "test-client",
 				clientSecret: "test-secret",
 				redirectURL:  "http://localhost/callback",

--- a/internal/frontend/auth/handlers_test.go
+++ b/internal/frontend/auth/handlers_test.go
@@ -355,6 +355,14 @@ func (p *failingAuthProvider) Name() string {
 	return p.name
 }
 
+func (p *failingAuthProvider) DisplayName() string {
+	return p.name
+}
+
+func (p *failingAuthProvider) IconURL() string {
+	return ""
+}
+
 func (p *failingAuthProvider) LoginURL(state string) string {
 	return "https://fail.example.com/login?state=" + url.QueryEscape(state)
 }

--- a/internal/frontend/auth/manager_test.go
+++ b/internal/frontend/auth/manager_test.go
@@ -23,6 +23,14 @@ func (p *testAuthProvider) Name() string {
 	return p.name
 }
 
+func (p *testAuthProvider) DisplayName() string {
+	return p.name
+}
+
+func (p *testAuthProvider) IconURL() string {
+	return ""
+}
+
 func (p *testAuthProvider) LoginURL(state string) string {
 	return p.loginURL + "?state=" + state
 }

--- a/internal/frontend/auth/provider.go
+++ b/internal/frontend/auth/provider.go
@@ -22,13 +22,15 @@ var (
 
 type ProviderConfig struct {
 	Name         string
+	DisplayName  string
 	Type         string
-	IssuerURL    string
+	Endpoint     string
 	ClientID     string
 	ClientSecret string
 	RedirectURL  string
 	ForgeURL     string
 	AuthURL      string
+	IconURL      string
 	Insecure     bool
 }
 
@@ -45,6 +47,8 @@ type AuthenticatedUser struct {
 type AuthProvider interface {
 	Type() string
 	Name() string
+	DisplayName() string
+	IconURL() string
 	LoginURL(state string) string
 	HandleCallback(ctx context.Context, code string) (*AuthenticatedUser, error)
 	RefreshToken(ctx context.Context, refreshToken string) (*AuthenticatedUser, error)

--- a/internal/frontend/view/icons.templ
+++ b/internal/frontend/view/icons.templ
@@ -106,3 +106,11 @@ templ IconEyeSlash(class string) {
 		<path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12c1.292 4.338 5.31 7.5 10.066 7.5.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88"></path>
 	</svg>
 }
+
+// IconKey renders a Heroicon outlined key icon, used as a generic OIDC provider icon.
+templ IconKey(class string) {
+	<svg class={ class } xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+		<path strokeLinecap="round" strokeLinejoin="round" d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z" />
+	</svg>
+
+}

--- a/internal/frontend/view/icons_templ.go
+++ b/internal/frontend/view/icons_templ.go
@@ -727,4 +727,65 @@ func IconEyeSlash(class string) templ.Component {
 	})
 }
 
+// IconKey renders a Heroicon outlined key icon, used as a generic OIDC provider icon.
+func IconKey(class string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var46 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var46 == nil {
+			templ_7745c5c3_Var46 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		var templ_7745c5c3_Var47 = []any{class}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var47...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<svg class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var48 string
+		templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var47).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `icons.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var48)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" strokeWidth=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var49 string
+		templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.ResolveAttributeValue(1.5)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `icons.templ`, Line: 112, Col: 105}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var49)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\" stroke=\"currentColor\" className=\"size-6\"><path strokeLinecap=\"round\" strokeLinejoin=\"round\" d=\"M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z\"></path></svg>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
 var _ = templruntime.GeneratedTemplate

--- a/internal/frontend/view/login.templ
+++ b/internal/frontend/view/login.templ
@@ -17,8 +17,20 @@ templ Login(auth viewmodel.AuthInfo) {
 				<div class="px-4 py-5 sm:p-6">
 					<div class="space-y-3">
 						for _, p := range auth.Providers {
-							<a href={ "/auth/login?provider=" + p.Name } hx-boost="false" class="flex items-center justify-center w-full px-4 py-3 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition duration-150 ease-in-out">
-								Sign in with { p.Name }
+							<a href={ "/auth/login?provider=" + p.Name } hx-boost="false" class="flex items-center justify-center gap-3 w-full px-4 py-3 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition duration-150 ease-in-out">
+								<div class="w-5 h-5 shrink-0">
+									if p.IconURL != "" {
+										<img src={ p.IconURL } alt="" class="w-5 h-5" onerror="this.style.display='none';this.nextElementSibling.style.display='block'" />
+										<div class="hidden w-5 h-5 text-gray-400">
+											@IconKey("w-5 h-5")
+										</div>
+									} else {
+										<div class="w-5 h-5 text-gray-400">
+											@IconKey("w-5 h-5")
+										</div>
+									}
+								</div>
+								<span class="truncate">Sign in with { p.DisplayName }</span>
 							</a>
 						}
 					</div>

--- a/internal/frontend/view/login_templ.go
+++ b/internal/frontend/view/login_templ.go
@@ -48,25 +48,69 @@ func Login(auth viewmodel.AuthInfo) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" hx-boost=\"false\" class=\"flex items-center justify-center w-full px-4 py-3 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition duration-150 ease-in-out\">Sign in with ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" hx-boost=\"false\" class=\"flex items-center justify-center gap-3 w-full px-4 py-3 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition duration-150 ease-in-out\"><div class=\"w-5 h-5 shrink-0\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var3 string
-			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(p.Name)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `login.templ`, Line: 21, Col: 29}
+			if p.IconURL != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<img src=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var3 string
+				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(p.IconURL)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `login.templ`, Line: 23, Col: 30}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" alt=\"\" class=\"w-5 h-5\" onerror=\"this.style.display='none';this.nextElementSibling.style.display='block'\"><div class=\"hidden w-5 h-5 text-gray-400\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = IconKey("w-5 h-5").Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"w-5 h-5 text-gray-400\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = IconKey("w-5 h-5").Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div><span class=\"truncate\">Sign in with ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</a>")
+			var templ_7745c5c3_Var4 string
+			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(p.DisplayName)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `login.templ`, Line: 33, Col: 59}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</span></a>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div></div></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/frontend/viewmodel/viewmodel.go
+++ b/internal/frontend/viewmodel/viewmodel.go
@@ -74,7 +74,9 @@ type AuthInfo struct {
 // AuthProviderInfo describes a single OAuth/OIDC provider that the user can
 // sign in with on the login page.
 type AuthProviderInfo struct {
-	Name string
+	Name        string
+	DisplayName string
+	IconURL     string
 }
 
 // GitRepoFieldLabel defines the human-readable label for a repository field

--- a/internal/frontend/web.go
+++ b/internal/frontend/web.go
@@ -102,7 +102,9 @@ func (h *WebHandler) buildAuthInfo(r *http.Request) viewmodel.AuthInfo {
 
 	for _, p := range h.authManager.List() {
 		info.Providers = append(info.Providers, viewmodel.AuthProviderInfo{
-			Name: p.Name(),
+			Name:        p.Name(),
+			DisplayName: p.DisplayName(),
+			IconURL:     p.IconURL(),
 		})
 	}
 


### PR DESCRIPTION
Also drops `IssuerURL` as this is always the same as `Endpoint`.